### PR TITLE
Rewrite HackForm to use CreateHandle, WindowHandle trickery

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -51,246 +51,52 @@ namespace Microsoft.Xna.Framework
 		// Wine change!
 		class HackForm : System.Windows.Forms.Form
 		{
-			private bool dirty = false;
-			private bool Dirty
+			public bool IsClosed;
+
+			private readonly IntPtr sdlHandle;
+
+			public HackForm(IntPtr window) : base()
 			{
-				get
-				{
-					return dirty;
-				}
-				set
-				{
-					if (value)
-					{
-						formBorderStyle = FormBorderStyle;
-						windowState = WindowState;
-					}
-					dirty = value;
-				}
+				IsClosed = false;
+				sdlHandle = window;
+				FormClosed += OnFormClosed;
+				CreateHandle();
 			}
 
-			private System.Windows.Forms.FormBorderStyle formBorderStyle =
-				System.Windows.Forms.FormBorderStyle.FixedDialog;
-			public new System.Windows.Forms.FormBorderStyle FormBorderStyle
+			private void OnFormClosed(object sender, EventArgs e)
 			{
-				get
-				{
-					if (Dirty)
-					{
-						return formBorderStyle;
-					}
-					uint flags = SDL.SDL_GetWindowFlags(sdlHandle);
-					if ((flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) != 0 || FakeFullscreenWindow)
-					{
-						return System.Windows.Forms.FormBorderStyle.None;
-					}
-					if ((flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE) != 0)
-					{
-						return System.Windows.Forms.FormBorderStyle.Sizable;
-					}
-					return System.Windows.Forms.FormBorderStyle.FixedDialog;
-				}
-				set
-				{
-					Dirty = true;
-					formBorderStyle = value;
-				}
+				IsClosed = true;
 			}
 
-			private System.Windows.Forms.FormWindowState windowState =
-				System.Windows.Forms.FormWindowState.Normal;
-			public new System.Windows.Forms.FormWindowState WindowState
+			protected override void CreateHandle()
 			{
-				get
+				FieldInfo winField = typeof(System.Windows.Forms.Control).GetField(
+					"_window",
+					BindingFlags.Instance | BindingFlags.NonPublic
+				);
+				if (winField == null)
 				{
-					if (Dirty)
-					{
-						return windowState;
-					}
-					uint flags = SDL.SDL_GetWindowFlags(sdlHandle);
-					if ((flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) != 0 || FakeFullscreenWindow)
-					{
-						return System.Windows.Forms.FormWindowState.Maximized;
-					}
-					if ((flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED) != 0)
-					{
-						return System.Windows.Forms.FormWindowState.Minimized;
-					}
-					return System.Windows.Forms.FormWindowState.Normal;
-				}
-				set
-				{
-					Dirty = true;
-					windowState = value;
-				}
-			}
-
-			private Rectangle windowedBounds = new Rectangle();
-			private Rectangle bounds = new Rectangle();
-			private Rectangle SDLBounds
-			{
-				get
-				{
-					return GetWindowBounds(sdlHandle);
-				}
-				set
-				{
-					SDL.SDL_SetWindowSize(
-						sdlHandle,
-						value.Width,
-						value.Height
-					);
-					SDL.SDL_SetWindowPosition(
-						sdlHandle,
-						value.X,
-						value.Y
+					winField = typeof(System.Windows.Forms.Control).GetField(
+						"window",
+						BindingFlags.Instance | BindingFlags.NonPublic
 					);
 				}
-			}
+				System.Windows.Forms.NativeWindow internalWindow =
+					(System.Windows.Forms.NativeWindow) winField.GetValue(this);
 
-			private IntPtr sdlHandle = IntPtr.Zero;
-			private bool FakeFullscreenWindow = false;
+				SDL.SDL_SysWMinfo info = new SDL.SDL_SysWMinfo();
+				SDL.SDL_GetWindowWMInfo(sdlHandle, ref info);
+				internalWindow.AssignHandle(info.info.win.window);
 
-			public HackForm() : base()
-			{
-				// FIXME: This might reduce Control size updates?
-				ResizeRedraw = false;
-			}
-
-			public IntPtr RecreateSDLWindow(IntPtr sdlWindow, string title)
-			{
-				/* Using the SDL window's GL context format,
-				 * create another SDL window using this Handle,
-				 * then destroy the old window
-				 */
-				SDL.SDL_SetHint(
-					SDL.SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT,
-					string.Format("{0:x8}", sdlWindow.ToInt32())
-				);
-				IntPtr formWindow = SDL.SDL_CreateWindowFrom(Handle);
-				SDL.SDL_SetHint(
-					SDL.SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT,
-					string.Empty
-				);
-				SDL.SDL_DestroyWindow(sdlWindow);
-
-				// Set a bunch of default values on SDL's side
-				SDL.SDL_SetWindowSize(
-					formWindow,
-					GraphicsDeviceManager.DefaultBackBufferWidth,
-					GraphicsDeviceManager.DefaultBackBufferHeight
-				);
-				SDL.SDL_SetWindowPosition(
-					formWindow,
-					SDL.SDL_WINDOWPOS_CENTERED,
-					SDL.SDL_WINDOWPOS_CENTERED
-				);
-				SDL.SDL_SetWindowTitle(formWindow, title);
-				SDL.SDL_SetWindowResizable(formWindow, SDL.SDL_bool.SDL_FALSE);
-
-				// Reload this, so entry points work again
-				SDL.SDL_GL_LoadLibrary(null);
-
-				// Set this Forms value just to be safe
-				int fx, fy, fw, fh;
-				SDL.SDL_GetWindowPosition(formWindow, out fx, out fy);
-				SDL.SDL_GetWindowSize(formWindow, out fw, out fh);
-				SetBounds(fx, fy, fw, fh);
-
-				sdlHandle = formWindow;
-				return formWindow;
-			}
-
-			public void SDLWindowChanged()
-			{
-				bounds = SDLBounds;
-				if ((SDL.SDL_GetWindowFlags(sdlHandle) & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN) == 0 && !FakeFullscreenWindow)
+				// This throws an Exception internally and skips an UpdateReflectParent call!
+				try
 				{
-					windowedBounds = bounds;
+					base.CreateHandle();
 				}
-			}
-
-			public void ApplyChanges(Game game)
-			{
-				if (!Dirty)
+				catch(Exception e)
 				{
-					return;
+					FNALoggerEXT.LogWarn(e.ToString());
 				}
-
-				GraphicsDeviceManager gdm = (GraphicsDeviceManager) game.Services.GetService(typeof(IGraphicsDeviceManager));
-				bool fullscreen = gdm.IsFullScreen;
-				bool borderless =
-					FormBorderStyle == System.Windows.Forms.FormBorderStyle.None;
-				bool maximized =
-					WindowState == System.Windows.Forms.FormWindowState.Maximized;
-				bool wasFakeFullscreenWindow = FakeFullscreenWindow;
-				FakeFullscreenWindow = maximized && borderless;
-
-				FNALoggerEXT.LogInfo(
-					"[wine-fna] Applying changes from HackForm to SDL window:" +
-					"\n\tCurrently fullscreen: " + fullscreen.ToString() +
-					"\n\tFake fullscreen: " + FakeFullscreenWindow.ToString() +
-					"\n\tBorder: " + FormBorderStyle.ToString() +
-					"\n\tState: " + WindowState.ToString()
-				);
-
-				if (FakeFullscreenWindow)
-				{
-					FNALoggerEXT.LogInfo("[wine-fna] Game expects borderless fullscreen... give it proper fullscreen instead.");
-
-					if (!fullscreen)
-					{
-						windowedBounds = SDLBounds;
-					}
-
-					FNALoggerEXT.LogInfo(
-						"[wine-fna] Last window size: " +
-						windowedBounds.ToString()
-					);
-
-					// This feels so wrong...
-					DisplayMode dm = gdm.GraphicsDevice.DisplayMode;
-					gdm.PreferredBackBufferWidth = dm.Width;
-					gdm.PreferredBackBufferHeight = dm.Height;
-					gdm.ApplyChanges();
-
-					bounds = SDLBounds;
-				}
-				else
-				{
-					if (wasFakeFullscreenWindow)
-					{
-						FNALoggerEXT.LogInfo("[wine-fna] Leaving fake borderless fullscreen");
-						gdm.IsFullScreen = false;
-					}
-					game.Window.IsBorderlessEXT = borderless;
-					if (maximized)
-					{
-						SDL.SDL_MaximizeWindow(sdlHandle);
-						bounds = SDLBounds;
-					}
-					else
-					{
-						SDL.SDL_RestoreWindow(sdlHandle);
-						SDLBounds = bounds = windowedBounds;
-					}
-
-					// This also feels so wrong...
-					FNALoggerEXT.LogInfo(
-						"[wine-fna] New window size: " + bounds.ToString()
-					);
-					gdm.PreferredBackBufferWidth = bounds.Width;
-					gdm.PreferredBackBufferHeight = bounds.Height;
-					gdm.ApplyChanges();
-				}
-
-				Dirty = false;
-			}
-
-			protected override void WndProc(ref System.Windows.Forms.Message m)
-			{
-				// TODO: Fix this to prevent Control size updates
-				base.WndProc(ref m);
 			}
 		}
 		private static Dictionary<IntPtr, HackForm> forms = new Dictionary<IntPtr, HackForm>();
@@ -603,8 +409,7 @@ namespace Microsoft.Xna.Framework
 			);
 
 			// Wine change!
-			HackForm form = new HackForm();
-			window = form.RecreateSDLWindow(window, title);
+			HackForm form = new HackForm(window);
 			forms.Add(window, form);
 
 			if (window == IntPtr.Zero)
@@ -1259,13 +1064,6 @@ namespace Microsoft.Xna.Framework
 							if (GetWindowResizable(game.Window.Handle))
 							{
 								((FNAWindow) game.Window).INTERNAL_ClientSizeChanged();
-
-								// Wine change!
-								HackForm form;
-								if (forms.TryGetValue(game.Window.Handle, out form))
-								{
-									form.SDLWindowChanged();
-								}
 							}
 						}
 						else if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_EXPOSED)
@@ -1389,7 +1187,10 @@ namespace Microsoft.Xna.Framework
 				game.Tick();
 
 				// Wine change!
-				forms[game.Window.Handle].ApplyChanges(game);
+				if (forms[game.Window.Handle].IsClosed)
+				{
+					game.RunApplication = false;
+				}
 			}
 
 			// Okay, we don't care about the events anymore

--- a/src/Input/Mouse.cs
+++ b/src/Input/Mouse.cs
@@ -20,10 +20,21 @@ namespace Microsoft.Xna.Framework.Input
 	{
 		#region Public Properties
 
+		private static IntPtr INTERNAL_windowHandle;
 		public static IntPtr WindowHandle
 		{
-			get;
-			set;
+			get
+			{
+				return INTERNAL_windowHandle;
+			}
+			set
+			{
+				// Wine change! Ignore handles that aren't SDL windows
+				if (SDL2.SDL.SDL_GetWindowID(value) != 0)
+				{
+					INTERNAL_windowHandle = value;
+				}
+			}
 		}
 
 		public static bool IsRelativeMouseModeEXT

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -61,10 +61,21 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			}
 		}
 
+		private static IntPtr INTERNAL_windowHandle;
 		public static IntPtr WindowHandle
 		{
-			get;
-			set;
+			get
+			{
+				return INTERNAL_windowHandle;
+			}
+			set
+			{
+				// Wine change! Ignore handles that aren't SDL windows
+				if (SDL2.SDL.SDL_GetWindowID(value) != 0)
+				{
+					INTERNAL_windowHandle = value;
+				}
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
This redoes the Forms sludge in a way that makes a little more sense and is easier to manage, vs multiple windows with copied pixel formats and other such hacks. It also adds a barrier to the WindowHandle pointers in the XNA API to only pay attention to SDL window handles, of which there is usually only one anyway, but sometimes games try to redundantly set the pointer, which is a HWND based on the _other_ Win32 hack in GameWindow.Handle.