### PR TITLE
Port FNA over Media Foundation instead of Theorafile.

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -337,7 +337,7 @@
 		<Compile Include="src\Vector4.cs" />
 		<Compile Include="lib\SDL2-CS\src\SDL2.cs" />
 		<Compile Include="lib\FAudio\csharp\FAudio.cs" />
-		<Compile Include="lib\Theorafile\csharp\Theorafile.cs" />
+		<Compile Include="lib\FNAMF\Theorafile.cs" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="app.config" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -408,7 +408,7 @@
     <Compile Include="src\Vector4.cs" />
     <Compile Include="lib\SDL2-CS\src\SDL2.cs" />
     <Compile Include="lib\FAudio\csharp\FAudio.cs" />
-    <Compile Include="lib\Theorafile\csharp\Theorafile.cs" />
+    <Compile Include="lib\FNAMF\Theorafile.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ SRC = \
 	src/Vector4.cs \
 	lib/SDL2-CS/src/SDL2.cs \
 	lib/FAudio/csharp/FAudio.cs \
-	lib/Theorafile/csharp/Theorafile.cs
+	lib/FNAMF/Theorafile.cs
 
 RESDIR = src/Graphics/Effect/StockEffects/FXB
 RESNAME = Microsoft.Xna.Framework.Graphics.Effect.Resources

--- a/app.config
+++ b/app.config
@@ -4,8 +4,8 @@
 	<dllmap dll="SDL2" target="$mono_libdir\SDL2-x86_64.dll" os="windows" cpu="x86-64"/>
 	<dllmap dll="FAudio" target="$mono_libdir\FAudio-x86.dll" os="windows" cpu="x86"/>
 	<dllmap dll="FAudio" target="$mono_libdir\FAudio-x86_64.dll" os="windows" cpu="x86-64"/>
-	<dllmap dll="libtheorafile" target="$mono_libdir\libtheorafile-x86.dll" os="windows" cpu="x86"/>
-	<dllmap dll="libtheorafile" target="$mono_libdir\libtheorafile-x86_64.dll" os="windows" cpu="x86-64"/>
+	<dllmap dll="FNAMF" target="$mono_libdir\FNAMF-x86.dll" os="windows" cpu="x86"/>
+	<dllmap dll="FNAMF" target="$mono_libdir\FNAMF-x86_64.dll" os="windows" cpu="x86-64"/>
 	<dllmap dll="FNA3D" target="$mono_libdir\FNA3D-x86.dll" os="windows" cpu="x86"/>
 	<dllmap dll="FNA3D" target="$mono_libdir\FNA3D-x86_64.dll" os="windows" cpu="x86-64"/>
 </configuration>

--- a/lib/FNAMF/Makefile
+++ b/lib/FNAMF/Makefile
@@ -1,0 +1,18 @@
+C_SRCS = \
+    main.c \
+
+H_SRCS = \
+    $(SRCDIR)/../../wine/debug.h \
+    $(SRCDIR)/../../wine/heap.h \
+
+all: FNAMF.dll
+.PHONY: all
+
+%.o: $(SRCDIR)/%.c $(H_SRCS)
+	$(CC) -o $@ -D_WIN32_WINNT=0x0602 --std=c99 -c -Wall -Wno-format -Werror -Wno-pragma-pack -I$(SRCDIR)/../.. -I$(SRCDIR)/../../wine $<
+
+debug.o: $(SRCDIR)/../../wine/debug.c $(H_SRCS)
+	$(CC) -o $@ -D_WIN32_WINNT=0x0602 -D__WINESRC__ --std=c99 -c -Wall -Wno-format -Werror -I$(SRCDIR)/../.. -I$(SRCDIR)/../../wine $<
+
+FNAMF.dll: $(C_SRCS:%.c=%.o) debug.o
+	$(CC) -o $@ -shared -Wl,--kill-at $(C_SRCS:%.c=%.o) debug.o -luuid -lmfplat -lmfreadwrite -lmfuuid

--- a/lib/FNAMF/Theorafile.cs
+++ b/lib/FNAMF/Theorafile.cs
@@ -1,0 +1,111 @@
+/* 
+ * Copyright (c) 2021 Rémi Bernon for CodeWeavers.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+#endregion
+
+public static class Theorafile
+{
+	#region Native Library Name
+
+	const string nativeLibName = "FNAMF";
+
+	#endregion
+
+	#region libtheora Enumerations
+
+	public enum th_pixel_fmt
+	{
+		TH_PF_420,
+		TH_PF_RSVD,
+		TH_PF_422,
+		TH_PF_444,
+		TH_PF_NFORMATS
+	}
+
+	#endregion
+
+	#region Theorafile Implementation
+
+	[DllImport(nativeLibName, EntryPoint = "tf_fopen", CallingConvention = CallingConvention.Cdecl)]
+	private static extern void _tf_fopen([In, MarshalAs(UnmanagedType.LPWStr)] string url, [Out] out IntPtr reader);
+
+	public static unsafe int tf_fopen(string fname, out IntPtr file)
+	{
+		_tf_fopen(fname, out file);
+		if (file.Equals(0)) throw new NullReferenceException();
+		return 0;
+	}
+
+	[DllImport(nativeLibName, EntryPoint = "tf_close", CallingConvention = CallingConvention.Cdecl)]
+	private static extern void _tf_close([In] IntPtr file);
+
+	public static int tf_close(ref IntPtr file)
+	{
+		_tf_close(file);
+		file = IntPtr.Zero;
+		return 0;
+	}
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_hasaudio(IntPtr file);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_hasvideo(IntPtr file);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern void tf_videoinfo(
+		IntPtr file,
+		out int width,
+		out int height,
+		out double fps,
+		out th_pixel_fmt fmt
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern void tf_audioinfo(
+		IntPtr file,
+		out int channels,
+		out int samplerate
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_setaudiotrack(IntPtr file, int track);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_eos(IntPtr file);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern void tf_reset(IntPtr file);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_readvideo(IntPtr file, IntPtr buffer, int numframes);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_readaudio(IntPtr file, IntPtr buffer, int length);
+
+	#endregion
+}

--- a/lib/FNAMF/main.c
+++ b/lib/FNAMF/main.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2020 Rémi Bernon for CodeWeavers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <windows.h>
+#include <stdio.h>
+
+#define COBJMACROS
+#include <mfidl.h>
+#include <mfapi.h>
+#include <mfreadwrite.h>
+
+#include "wine/debug.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(fnamf);
+
+struct context
+{
+    IMFSourceReader *reader;
+    DWORD video_stream;
+    DWORD audio_stream;
+
+    IMFMediaBuffer *audio_buffer;
+    BOOL eos;
+};
+
+static void set_audio_media_type(struct context *ctx)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+
+    IMFSourceReader_SetStreamSelection(ctx->reader, ctx->audio_stream, FALSE);
+
+    if (SUCCEEDED(hr = MFCreateMediaType(&type)))
+    {
+        hr = IMFMediaType_SetGUID(type, &MF_MT_MAJOR_TYPE, &MFMediaType_Audio);
+
+        if (SUCCEEDED(hr))
+            hr = IMFMediaType_SetGUID(type, &MF_MT_SUBTYPE, &MFAudioFormat_Float);
+
+        if (SUCCEEDED(hr))
+            hr = IMFSourceReader_SetCurrentMediaType(ctx->reader, ctx->audio_stream, NULL, type);
+
+        IMFMediaType_Release(type);
+    }
+
+    IMFSourceReader_SetStreamSelection(ctx->reader, ctx->audio_stream, SUCCEEDED(hr));
+}
+
+static void set_video_media_type(struct context *ctx)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+
+    IMFSourceReader_SetStreamSelection(ctx->reader, ctx->video_stream, FALSE);
+
+    if (SUCCEEDED(hr = MFCreateMediaType(&type)))
+    {
+        hr = IMFMediaType_SetGUID(type, &MF_MT_MAJOR_TYPE, &MFMediaType_Video);
+
+        if (SUCCEEDED(hr))
+            hr = IMFMediaType_SetGUID(type, &MF_MT_SUBTYPE, &MFVideoFormat_I420);
+
+        if (SUCCEEDED(hr))
+            hr = IMFSourceReader_SetCurrentMediaType(ctx->reader, ctx->video_stream, NULL, type);
+
+        IMFMediaType_Release(type);
+    }
+
+    IMFSourceReader_SetStreamSelection(ctx->reader, ctx->video_stream, SUCCEEDED(hr));
+}
+
+void CDECL tf_fopen(const WCHAR *url, struct context **ctx)
+{
+    IMFSourceReader *reader;
+    IMFAttributes *attributes;
+    HRESULT hr;
+
+    WINE_TRACE("url %s, ctx %p.\n", wine_dbgstr_w(url), ctx);
+
+    *ctx = NULL;
+    if (FAILED(hr = MFCreateAttributes(&attributes, 1)))
+        return;
+
+    hr = IMFAttributes_SetUINT32(attributes, &MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, TRUE);
+    if (SUCCEEDED(hr))
+    {
+        hr = MFCreateSourceReaderFromURL(url, attributes, &reader);
+    }
+    IMFAttributes_Release(attributes);
+
+    if (SUCCEEDED(hr))
+    {
+        if (!(*ctx = calloc(1, sizeof(**ctx))))
+            IMFSourceReader_Release(reader);
+        else
+        {
+            (*ctx)->reader = reader;
+            (*ctx)->video_stream = MF_SOURCE_READER_FIRST_VIDEO_STREAM;
+            (*ctx)->audio_stream = MF_SOURCE_READER_FIRST_AUDIO_STREAM;
+            set_video_media_type(*ctx);
+            set_audio_media_type(*ctx);
+        }
+    }
+
+    WINE_TRACE("ret ctx %p, reader %p, hr %#x.\n", *ctx, reader, hr);
+}
+
+void CDECL tf_close(struct context *ctx)
+{
+    WINE_TRACE("ctx %p.\n", ctx);
+    if (ctx->audio_buffer) IMFMediaBuffer_Release(ctx->audio_buffer);
+    IMFSourceReader_Release(ctx->reader);
+    free(ctx);
+}
+
+INT CDECL tf_hasaudio(struct context *ctx)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+    BOOL selected;
+    GUID guid;
+
+    WINE_TRACE("ctx %p.\n", ctx);
+
+    hr = IMFSourceReader_GetStreamSelection(ctx->reader, ctx->audio_stream, &selected);
+    if (FAILED(hr) || !selected)
+        return FALSE;
+
+    hr = IMFSourceReader_GetCurrentMediaType(ctx->reader, ctx->audio_stream, &type);
+    if (FAILED(hr))
+        return FALSE;
+
+    hr = IMFMediaType_GetGUID(type, &MF_MT_MAJOR_TYPE, &guid);
+    IMFMediaType_Release(type);
+    return SUCCEEDED(hr) && IsEqualGUID(&guid, &MFMediaType_Audio);
+}
+
+INT CDECL tf_hasvideo(struct context *ctx)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+    BOOL selected;
+    GUID guid;
+
+    WINE_TRACE("ctx %p.\n", ctx);
+
+    hr = IMFSourceReader_GetStreamSelection(ctx->reader, ctx->video_stream, &selected);
+    if (FAILED(hr) || !selected)
+        return FALSE;
+
+    hr = IMFSourceReader_GetCurrentMediaType(ctx->reader, ctx->video_stream, &type);
+    if (FAILED(hr))
+        return FALSE;
+
+    hr = IMFMediaType_GetGUID(type, &MF_MT_MAJOR_TYPE, &guid);
+    IMFMediaType_Release(type);
+    return SUCCEEDED(hr) && IsEqualGUID(&guid, &MFMediaType_Video);
+}
+
+void CDECL tf_videoinfo(struct context *ctx, INT *width, INT *height, double *fps, INT *format)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+    UINT64 size, rate;
+    BOOL selected;
+
+    *width = *height = *fps = *format = 0;
+
+    WINE_TRACE("ctx %p, width %p, height %p, format %p, format %p.\n", ctx, width, height, fps, format);
+
+    hr = IMFSourceReader_GetStreamSelection(ctx->reader, ctx->video_stream, &selected);
+    if (FAILED(hr) || !selected)
+        return;
+
+    hr = IMFSourceReader_GetCurrentMediaType(ctx->reader, ctx->video_stream, &type);
+    if (FAILED(hr))
+        return;
+
+    hr = IMFMediaType_GetUINT64(type, &MF_MT_FRAME_SIZE, &size);
+    if (SUCCEEDED(hr))
+        hr = IMFMediaType_GetUINT64(type, &MF_MT_FRAME_RATE, &rate);
+
+    if (SUCCEEDED(hr))
+    {
+        *format = 0 /* I420 */;
+        *width = (UINT32)(size >> 32);
+        *height = (UINT32)(size >> 0);
+        *fps = (double)(rate >> 32) / (double)(rate & 0xffffffff);
+    }
+
+    IMFMediaType_Release(type);
+    WINE_TRACE("ret width %d, height %d, fps %f, format %d, hr %#x.\n", *width, *height, *fps, *format, hr);
+}
+
+void CDECL tf_audioinfo(struct context *ctx, INT *channels, INT *samplerate)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+    BOOL selected;
+
+    *channels = 0;
+    *samplerate = 0;
+
+    WINE_TRACE("ctx %p, channels %p, samplerate %p.\n", ctx, channels, samplerate);
+
+    hr = IMFSourceReader_GetStreamSelection(ctx->reader, ctx->audio_stream, &selected);
+    if (FAILED(hr) || !selected)
+        return;
+
+    hr = IMFSourceReader_GetCurrentMediaType(ctx->reader, ctx->audio_stream, &type);
+    if (FAILED(hr))
+        return;
+
+    hr = IMFMediaType_GetUINT32(type, &MF_MT_AUDIO_NUM_CHANNELS, (UINT32 *)channels);
+    if (SUCCEEDED(hr))
+        hr = IMFMediaType_GetUINT32(type, &MF_MT_AUDIO_SAMPLES_PER_SECOND, (UINT32 *)samplerate);
+
+    if (FAILED(hr))
+    {
+        *channels = 0;
+        *samplerate = 0;
+    }
+
+    IMFMediaType_Release(type);
+    WINE_TRACE("ret channels %d, samplerate %d, hr %#x.\n", *channels, *samplerate, hr);
+}
+
+INT CDECL tf_setaudiotrack(struct context *ctx, INT track)
+{
+    IMFMediaType *type;
+    HRESULT hr;
+    DWORD i = 0;
+    GUID guid;
+
+    WINE_TRACE("ctx %p.\n", ctx);
+
+    while (1)
+    {
+        hr = IMFSourceReader_GetCurrentMediaType(ctx->reader, i++, &type);
+        if (FAILED(hr))
+            return FALSE;
+
+        hr = IMFMediaType_GetGUID(type, &MF_MT_MAJOR_TYPE, &guid);
+        IMFMediaType_Release(type);
+        if (FAILED(hr))
+            return FALSE;
+
+        if (IsEqualGUID(&guid, &MFMediaType_Audio) && !track--)
+            break;
+    }
+
+    ctx->audio_stream = i - 1;
+    set_audio_media_type(ctx);
+    return TRUE;
+}
+
+INT CDECL tf_eos(struct context *ctx, INT track)
+{
+    WINE_TRACE("ctx %p.\n", ctx);
+    return ctx->eos;
+}
+
+void CDECL tf_reset(struct context *ctx)
+{
+    PROPVARIANT pos;
+    HRESULT hr;
+
+    WINE_TRACE("ctx %p.\n", ctx);
+
+    pos.vt = VT_I8;
+    pos.hVal.QuadPart = 0;
+    hr = IMFSourceReader_SetCurrentPosition(ctx->reader, &GUID_NULL, &pos);
+    if (FAILED(hr))
+        WINE_ERR("IMFSourceReader_SetCurrentPosition returned %#x.\n", hr);
+}
+
+INT CDECL tf_readvideo(struct context *ctx, void *dst, int numframes)
+{
+    IMFMediaBuffer *buffer;
+    IMFSample *sample;
+    HRESULT hr;
+    DWORD flags, len = 0;
+    BYTE *src;
+
+    WINE_TRACE("ctx %p, dst %p, numframes %d.\n", ctx, dst, numframes);
+    while (1)
+    {
+        hr = IMFSourceReader_ReadSample(ctx->reader, ctx->video_stream, 0, NULL, &flags, NULL, &sample);
+        if (flags & MF_SOURCE_READERF_ENDOFSTREAM) ctx->eos = TRUE;
+
+        if (FAILED(hr) || !sample)
+            return FALSE;
+
+        if (!numframes--)
+            break;
+        IMFSample_Release(sample);
+    }
+
+    hr = IMFSample_ConvertToContiguousBuffer(sample, &buffer);
+    IMFSample_Release(sample);
+    if (FAILED(hr))
+        return FALSE;
+
+    hr = IMFMediaBuffer_Lock(buffer, &src, NULL, &len);
+    if (SUCCEEDED(hr))
+    {
+        memcpy(dst, src, len);
+        IMFMediaBuffer_Unlock(buffer);
+    }
+    IMFMediaBuffer_Release(buffer);
+
+    WINE_TRACE("ret len %d, hr %#x\n", len, hr);
+
+    return len ? TRUE : FALSE;
+}
+
+INT CDECL tf_readaudio(struct context *ctx, float *dst, int dst_count)
+{
+    IMFSample *sample;
+    HRESULT hr;
+    DWORD len = 0, flags;
+    float *src;
+
+    WINE_TRACE("ctx %p, dst %p, dst_count %d.\n", ctx, dst, dst_count);
+
+    if (ctx->audio_buffer)
+        hr = S_OK;
+    else
+    {
+        hr = IMFSourceReader_ReadSample(ctx->reader, ctx->audio_stream, 0, NULL, &flags, NULL, &sample);
+        if (flags & MF_SOURCE_READERF_ENDOFSTREAM) ctx->eos = TRUE;
+
+        if (SUCCEEDED(hr) && sample)
+        {
+            hr = IMFSample_ConvertToContiguousBuffer(sample, &ctx->audio_buffer);
+            IMFSample_Release(sample);
+        }
+    }
+
+    if (FAILED(hr))
+        dst_count = -1;
+    else if (!ctx->audio_buffer || ctx->eos)
+        dst_count = 0;
+    else
+    {
+        hr = IMFMediaBuffer_Lock(ctx->audio_buffer, (BYTE **)&src, NULL, &len);
+        if (SUCCEEDED(hr))
+        {
+            dst_count = min(len / sizeof(float), dst_count);
+            memcpy(dst, src, dst_count * sizeof(float));
+            len -= dst_count * sizeof(float);
+
+            memcpy(src, src + dst_count, len);
+            hr = IMFMediaBuffer_SetCurrentLength(ctx->audio_buffer, len);
+            IMFMediaBuffer_Unlock(ctx->audio_buffer);
+        }
+
+        if (FAILED(hr) || len == 0)
+        {
+            IMFMediaBuffer_Release(ctx->audio_buffer);
+            ctx->audio_buffer = NULL;
+        }
+    }
+
+    WINE_TRACE("ret len %d\n", dst_count);
+    return dst_count;
+}
+
+BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, void *res)
+{
+    WINE_TRACE("instance %p, reason %x, res %p\n", instance, reason, res);
+
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        MFStartup(MF_VERSION, MFSTARTUP_FULL);
+        break;
+    case DLL_PROCESS_DETACH:
+        MFShutdown();
+        break;
+    }
+    return TRUE;
+}

--- a/src/Content/ContentReaders/SongReader.cs
+++ b/src/Content/ContentReaders/SongReader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		#region Private Supported File Extensions Variable
 
-		static string[] supportedExtensions = new string[] { ".ogg", ".oga" };
+		static string[] supportedExtensions = new string[] { ".ogg", ".oga", ".wma" };
 
 		#endregion
 

--- a/src/Content/ContentReaders/VideoReader.cs
+++ b/src/Content/ContentReaders/VideoReader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		#region Private Supported File Extensions Variable
 
-		static string[] supportedExtensions = new string[] { ".ogv", ".ogg" };
+		static string[] supportedExtensions = new string[] { ".ogv", ".ogg", ".wmv" };
 
 		#endregion
 

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -131,29 +131,6 @@ namespace Microsoft.Xna.Framework.Media
 			float framesPerSecond,
 			VideoSoundtrackType soundtrackType
 		) : this(fileName, device) {
-			/* If you got here, you've still got the XNB file! Well done!
-			 * Except if you're running FNA, you're not using the WMV anymore.
-			 * But surely it's the same video, right...?
-			 * Well, consider this a check more than anything. If this bothers
-			 * you, just remove the XNB file and we'll read the OGV straight up.
-			 * -flibit
-			 */
-			if (width != Width || height != Height)
-			{
-				throw new InvalidOperationException(
-					"XNB/OGV width/height mismatch!" +
-					" Width: " + Width.ToString() +
-					" Height: " + Height.ToString()
-				);
-			}
-			if (Math.Abs(FramesPerSecond - framesPerSecond) >= 1.0f)
-			{
-				throw new InvalidOperationException(
-					"XNB/OGV framesPerSecond mismatch!" +
-					" FPS: " + FramesPerSecond.ToString()
-				);
-			}
-
 			// FIXME: Oh, hey! I wish we had this info in Theora!
 			Duration = TimeSpan.FromMilliseconds(durationMS);
 			needsDurationHack = false;

--- a/wine/LICENSE
+++ b/wine/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) 1993-2020 the Wine project authors (see the file AUTHORS
+for a complete list)
+
+Wine is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation; either version 2.1 of the License, or (at
+your option) any later version. 
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+A copy of the GNU Lesser General Public License is included in the
+Wine distribution in the file COPYING.LIB. If you did not receive this
+copy, write to the Free Software Foundation, Inc., 51 Franklin St,
+Fifth Floor, Boston, MA 02110-1301, USA.

--- a/wine/debug.c
+++ b/wine/debug.c
@@ -1,0 +1,256 @@
+/*
+ * Fallbacks for debugging functions when running on Windows
+ *
+ * Copyright 2019 Alexandre Julliard
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifdef _WIN32
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include "windef.h"
+#include "winbase.h"
+#include "wine/debug.h"
+#include "wine/heap.h"
+
+WINE_DECLARE_DEBUG_CHANNEL(pid);
+WINE_DECLARE_DEBUG_CHANNEL(timestamp);
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
+#endif
+
+static const char * (__cdecl *p__wine_dbg_strdup)( const char *str );
+static int (__cdecl *p__wine_dbg_output)( const char *str );
+static unsigned char (__cdecl *p__wine_dbg_get_channel_flags)( struct __wine_debug_channel *channel );
+static int (__cdecl *p__wine_dbg_header)( enum __wine_debug_class cls,
+                                          struct __wine_debug_channel *channel,
+                                          const char *function );
+
+static const char * const debug_classes[] = { "fixme", "err", "warn", "trace" };
+
+static unsigned char default_flags = (1 << __WINE_DBCL_ERR) | (1 << __WINE_DBCL_FIXME);
+static int nb_debug_options = -1;
+static int options_size;
+static struct __wine_debug_channel *debug_options;
+static DWORD partial_line_tid;  /* id of the last thread to output a partial line */
+
+static void load_func( void **func, const char *name, void *def )
+{
+    if (!*func)
+    {
+        DWORD err = GetLastError();
+        HMODULE module = GetModuleHandleA( "ntdll.dll" );
+        void *proc = GetProcAddress( module, name );
+        InterlockedExchangePointer( func, proc ? proc : def );
+        SetLastError( err );
+    }
+}
+#define LOAD_FUNC(name) load_func( (void **)&p ## name, #name, fallback ## name )
+
+
+/* add a new debug option at the end of the option list */
+static void add_option( const char *name, unsigned char set, unsigned char clear )
+{
+    int min = 0, max = nb_debug_options - 1, pos, res;
+
+    if (!name[0])  /* "all" option */
+    {
+        default_flags = (default_flags & ~clear) | set;
+        return;
+    }
+    if (strlen(name) >= sizeof(debug_options[0].name)) return;
+
+    while (min <= max)
+    {
+        pos = (min + max) / 2;
+        res = strcmp( name, debug_options[pos].name );
+        if (!res)
+        {
+            debug_options[pos].flags = (debug_options[pos].flags & ~clear) | set;
+            return;
+        }
+        if (res < 0) max = pos - 1;
+        else min = pos + 1;
+    }
+    if (nb_debug_options >= options_size)
+    {
+        options_size = max( options_size * 2, 16 );
+        debug_options = heap_realloc( debug_options, options_size * sizeof(debug_options[0]) );
+    }
+
+    pos = min;
+    if (pos < nb_debug_options) memmove( &debug_options[pos + 1], &debug_options[pos],
+                                         (nb_debug_options - pos) * sizeof(debug_options[0]) );
+    strcpy( debug_options[pos].name, name );
+    debug_options[pos].flags = (default_flags & ~clear) | set;
+    nb_debug_options++;
+}
+
+/* parse a set of debugging option specifications and add them to the option list */
+static void parse_options( const char *str )
+{
+    char *opt, *next, *options;
+    unsigned int i;
+
+    if (!(options = _strdup(str))) return;
+    for (opt = options; opt; opt = next)
+    {
+        const char *p;
+        unsigned char set = 0, clear = 0;
+
+        if ((next = strchr( opt, ',' ))) *next++ = 0;
+
+        p = opt + strcspn( opt, "+-" );
+        if (!p[0]) p = opt;  /* assume it's a debug channel name */
+
+        if (p > opt)
+        {
+            for (i = 0; i < ARRAY_SIZE(debug_classes); i++)
+            {
+                int len = strlen(debug_classes[i]);
+                if (len != (p - opt)) continue;
+                if (!memcmp( opt, debug_classes[i], len ))  /* found it */
+                {
+                    if (*p == '+') set |= 1 << i;
+                    else clear |= 1 << i;
+                    break;
+                }
+            }
+            if (i == ARRAY_SIZE(debug_classes)) /* bad class name, skip it */
+                continue;
+        }
+        else
+        {
+            if (*p == '-') clear = ~0;
+            else set = ~0;
+        }
+        if (*p == '+' || *p == '-') p++;
+        if (!p[0]) continue;
+
+        if (!strcmp( p, "all" ))
+            default_flags = (default_flags & ~clear) | set;
+        else
+            add_option( p, set, clear );
+    }
+    free( options );
+}
+
+/* initialize all options at startup */
+static void init_options(void)
+{
+    char *wine_debug = getenv("WINEDEBUG");
+
+    nb_debug_options = 0;
+    if (wine_debug) parse_options( wine_debug );
+}
+
+/* FIXME: this is not 100% thread-safe */
+static const char * __cdecl fallback__wine_dbg_strdup( const char *str )
+{
+    static char *list[32];
+    static LONG pos;
+    char *ret = strdup( str );
+    int idx;
+
+    idx = InterlockedIncrement( &pos ) % ARRAY_SIZE(list);
+    free( InterlockedExchangePointer( (void **)&list[idx], ret ));
+    return ret;
+}
+
+static int __cdecl fallback__wine_dbg_output( const char *str )
+{
+    size_t len = strlen( str );
+
+    if (!len) return 0;
+    InterlockedExchange( (LONG *)&partial_line_tid, str[len - 1] != '\n' ? GetCurrentThreadId() : 0 );
+    return fwrite( str, 1, len, stderr );
+}
+
+static int __cdecl fallback__wine_dbg_header( enum __wine_debug_class cls,
+                                              struct __wine_debug_channel *channel,
+                                              const char *function )
+{
+    char buffer[200], *pos = buffer;
+
+    if (!(__wine_dbg_get_channel_flags( channel ) & (1 << cls))) return -1;
+
+    /* skip header if partial line and no other thread came in between */
+    if (partial_line_tid == GetCurrentThreadId()) return 0;
+
+    if (TRACE_ON(timestamp))
+    {
+        ULONG ticks = GetTickCount();
+        pos += sprintf( pos, "%3u.%03u:", ticks / 1000, ticks % 1000 );
+    }
+    if (TRACE_ON(pid)) pos += sprintf( pos, "%04x:", GetCurrentProcessId() );
+    pos += sprintf( pos, "%04x:", GetCurrentThreadId() );
+    if (function && cls < ARRAY_SIZE( debug_classes ))
+        snprintf( pos, sizeof(buffer) - (pos - buffer), "%s:%s:%s ",
+                  debug_classes[cls], channel->name, function );
+
+    return fwrite( buffer, 1, strlen(buffer), stderr );
+}
+
+static unsigned char __cdecl fallback__wine_dbg_get_channel_flags( struct __wine_debug_channel *channel )
+{
+    int min, max, pos, res;
+
+    if (nb_debug_options == -1) init_options();
+
+    min = 0;
+    max = nb_debug_options - 1;
+    while (min <= max)
+    {
+        pos = (min + max) / 2;
+        res = strcmp( channel->name, debug_options[pos].name );
+        if (!res) return debug_options[pos].flags;
+        if (res < 0) max = pos - 1;
+        else min = pos + 1;
+    }
+    /* no option for this channel */
+    if (channel->flags & (1 << __WINE_DBCL_INIT)) channel->flags = default_flags;
+    return default_flags;
+}
+
+const char * __cdecl __wine_dbg_strdup( const char *str )
+{
+    LOAD_FUNC( __wine_dbg_strdup );
+    return p__wine_dbg_strdup( str );
+}
+
+int __cdecl __wine_dbg_output( const char *str )
+{
+    LOAD_FUNC( __wine_dbg_output );
+    return p__wine_dbg_output( str );
+}
+
+unsigned char __cdecl __wine_dbg_get_channel_flags( struct __wine_debug_channel *channel )
+{
+    LOAD_FUNC( __wine_dbg_get_channel_flags );
+    return p__wine_dbg_get_channel_flags( channel );
+}
+
+int __cdecl __wine_dbg_header( enum __wine_debug_class cls, struct __wine_debug_channel *channel,
+                               const char *function )
+{
+    LOAD_FUNC( __wine_dbg_header );
+    return p__wine_dbg_header( cls, channel, function );
+}
+
+#endif  /* _WIN32 */

--- a/wine/debug.h
+++ b/wine/debug.h
@@ -1,0 +1,536 @@
+/*
+ * Wine debugging interface
+ *
+ * Copyright 1999 Patrik Stridvall
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __WINE_WINE_DEBUG_H
+#define __WINE_WINE_DEBUG_H
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <windef.h>
+#include <winbase.h>
+#ifndef GUID_DEFINED
+#include <guiddef.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct _GUID;
+
+/*
+ * Internal definitions (do not use these directly)
+ */
+
+enum __wine_debug_class
+{
+    __WINE_DBCL_FIXME,
+    __WINE_DBCL_ERR,
+    __WINE_DBCL_WARN,
+    __WINE_DBCL_TRACE,
+
+    __WINE_DBCL_INIT = 7  /* lazy init flag */
+};
+
+struct __wine_debug_channel
+{
+    unsigned char flags;
+    char name[15];
+};
+
+#ifndef WINE_NO_TRACE_MSGS
+# define __WINE_GET_DEBUGGING_TRACE(dbch) ((dbch)->flags & (1 << __WINE_DBCL_TRACE))
+#else
+# define __WINE_GET_DEBUGGING_TRACE(dbch) 0
+#endif
+
+#ifndef WINE_NO_DEBUG_MSGS
+# define __WINE_GET_DEBUGGING_WARN(dbch)  ((dbch)->flags & (1 << __WINE_DBCL_WARN))
+# define __WINE_GET_DEBUGGING_FIXME(dbch) ((dbch)->flags & (1 << __WINE_DBCL_FIXME))
+#else
+# define __WINE_GET_DEBUGGING_WARN(dbch)  0
+# define __WINE_GET_DEBUGGING_FIXME(dbch) 0
+#endif
+
+/* define error macro regardless of what is configured */
+#define __WINE_GET_DEBUGGING_ERR(dbch)  ((dbch)->flags & (1 << __WINE_DBCL_ERR))
+
+#define __WINE_GET_DEBUGGING(dbcl,dbch)  __WINE_GET_DEBUGGING##dbcl(dbch)
+
+#define __WINE_IS_DEBUG_ON(dbcl,dbch) \
+  (__WINE_GET_DEBUGGING##dbcl(dbch) && (__wine_dbg_get_channel_flags(dbch) & (1 << __WINE_DBCL##dbcl)))
+
+#ifdef __GNUC__
+
+#define __WINE_DPRINTF(dbcl,dbch) \
+  do { if(__WINE_GET_DEBUGGING(dbcl,(dbch))) { \
+       struct __wine_debug_channel * const __dbch = (dbch); \
+       const enum __wine_debug_class __dbcl = __WINE_DBCL##dbcl; \
+       __WINE_DBG_LOG
+
+#define __WINE_DBG_LOG(args...) \
+    wine_dbg_log( __dbcl, __dbch, __FUNCTION__, args); } } while(0)
+
+#define __WINE_PRINTF_ATTR(fmt,args) __attribute__((format (printf,fmt,args)))
+
+
+#ifdef WINE_NO_TRACE_MSGS
+#define WINE_TRACE(args...) do { } while(0)
+#define WINE_TRACE_(ch) WINE_TRACE
+#endif
+
+#ifdef WINE_NO_DEBUG_MSGS
+#define WINE_WARN(args...) do { } while(0)
+#define WINE_WARN_(ch) WINE_WARN
+#define WINE_FIXME(args...) do { } while(0)
+#define WINE_FIXME_(ch) WINE_FIXME
+#endif
+
+#elif defined(__SUNPRO_C)
+
+#define __WINE_DPRINTF(dbcl,dbch) \
+  do { if(__WINE_GET_DEBUGGING(dbcl,(dbch))) { \
+       struct __wine_debug_channel * const __dbch = (dbch); \
+       const enum __WINE_DEBUG_CLASS __dbcl = __WINE_DBCL##dbcl; \
+       __WINE_DBG_LOG
+
+#define __WINE_DBG_LOG(...) \
+   wine_dbg_log( __dbcl, __dbch, __func__, __VA_ARGS__); } } while(0)
+
+#define __WINE_PRINTF_ATTR(fmt,args)
+
+#ifdef WINE_NO_TRACE_MSGS
+#define WINE_TRACE(...) do { } while(0)
+#define WINE_TRACE_(ch) WINE_TRACE
+#endif
+
+#ifdef WINE_NO_DEBUG_MSGS
+#define WINE_WARN(...) do { } while(0)
+#define WINE_WARN_(ch) WINE_WARN
+#define WINE_FIXME(...) do { } while(0)
+#define WINE_FIXME_(ch) WINE_FIXME
+#endif
+
+#else  /* !__GNUC__ && !__SUNPRO_C */
+
+#define __WINE_DPRINTF(dbcl,dbch) \
+    (!__WINE_GET_DEBUGGING(dbcl,(dbch)) || \
+     (wine_dbg_log(__WINE_DBCL##dbcl,(dbch),__FILE__,"%d: ",__LINE__) == -1)) ? \
+     (void)0 : (void)wine_dbg_printf
+
+#define __WINE_PRINTF_ATTR(fmt, args)
+
+#endif  /* !__GNUC__ && !__SUNPRO_C */
+
+extern unsigned char __cdecl __wine_dbg_get_channel_flags( struct __wine_debug_channel *channel );
+extern const char * __cdecl __wine_dbg_strdup( const char *str );
+extern int __cdecl __wine_dbg_output( const char *str );
+extern int __cdecl __wine_dbg_header( enum __wine_debug_class cls, struct __wine_debug_channel *channel,
+                                      const char *function );
+
+/*
+ * Exported definitions and macros
+ */
+
+/* These functions return a printable version of a string, including
+   quotes.  The string will be valid for some time, but not indefinitely
+   as strings are re-used.  */
+
+#if (defined(__x86_64__) || defined(__aarch64__)) && defined(__GNUC__) && defined(__WINE_USE_MSVCRT)
+# define __wine_dbg_cdecl __cdecl
+# define __wine_dbg_va_list __builtin_ms_va_list
+# define __wine_dbg_va_start(list,arg) __builtin_ms_va_start(list,arg)
+# define __wine_dbg_va_end(list) __builtin_ms_va_end(list)
+#else
+# define __wine_dbg_cdecl
+# define __wine_dbg_va_list va_list
+# define __wine_dbg_va_start(list,arg) va_start(list,arg)
+# define __wine_dbg_va_end(list) va_end(list)
+#endif
+
+static const char * __wine_dbg_cdecl wine_dbg_sprintf( const char *format, ... ) __WINE_PRINTF_ATTR(1,2);
+static inline const char * __wine_dbg_cdecl wine_dbg_sprintf( const char *format, ... )
+{
+    char buffer[200];
+    __wine_dbg_va_list args;
+
+    __wine_dbg_va_start( args, format );
+    vsnprintf( buffer, sizeof(buffer), format, args );
+    __wine_dbg_va_end( args );
+    return __wine_dbg_strdup( buffer );
+}
+
+static int __wine_dbg_cdecl wine_dbg_printf( const char *format, ... ) __WINE_PRINTF_ATTR(1,2);
+static inline int __wine_dbg_cdecl wine_dbg_printf( const char *format, ... )
+{
+    char buffer[1024];
+    __wine_dbg_va_list args;
+
+    __wine_dbg_va_start( args, format );
+    vsnprintf( buffer, sizeof(buffer), format, args );
+    __wine_dbg_va_end( args );
+    return __wine_dbg_output( buffer );
+}
+
+static int __wine_dbg_cdecl wine_dbg_log( enum __wine_debug_class cls,
+                                          struct __wine_debug_channel *channel, const char *func,
+                                          const char *format, ... ) __WINE_PRINTF_ATTR(4,5);
+static inline int __wine_dbg_cdecl wine_dbg_log( enum __wine_debug_class cls,
+                                                 struct __wine_debug_channel *channel,
+                                                 const char *function, const char *format, ... )
+{
+    char buffer[1024];
+    __wine_dbg_va_list args;
+    int ret;
+
+    if (*format == '\1')  /* special magic to avoid standard prefix */
+    {
+        format++;
+        function = NULL;
+    }
+    if ((ret = __wine_dbg_header( cls, channel, function )) == -1) return ret;
+
+    __wine_dbg_va_start( args, format );
+    vsnprintf( buffer, sizeof(buffer), format, args );
+    __wine_dbg_va_end( args );
+    ret += __wine_dbg_output( buffer );
+    return ret;
+}
+
+static inline const char *wine_dbgstr_an( const char *str, int n )
+{
+    static const char hex[16] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+    char buffer[300], *dst = buffer;
+
+    if (!str) return "(null)";
+    if (!((ULONG_PTR)str >> 16)) return wine_dbg_sprintf( "#%04x", LOWORD(str) );
+    if (IsBadStringPtrA( str, n )) return "(invalid)";
+    if (n == -1) for (n = 0; str[n]; n++) ;
+    *dst++ = '"';
+    while (n-- > 0 && dst <= buffer + sizeof(buffer) - 9)
+    {
+        unsigned char c = *str++;
+        switch (c)
+        {
+        case '\n': *dst++ = '\\'; *dst++ = 'n'; break;
+        case '\r': *dst++ = '\\'; *dst++ = 'r'; break;
+        case '\t': *dst++ = '\\'; *dst++ = 't'; break;
+        case '"':  *dst++ = '\\'; *dst++ = '"'; break;
+        case '\\': *dst++ = '\\'; *dst++ = '\\'; break;
+        default:
+            if (c < ' ' || c >= 127)
+            {
+                *dst++ = '\\';
+                *dst++ = 'x';
+                *dst++ = hex[(c >> 4) & 0x0f];
+                *dst++ = hex[c & 0x0f];
+            }
+            else *dst++ = c;
+        }
+    }
+    *dst++ = '"';
+    if (n > 0)
+    {
+        *dst++ = '.';
+        *dst++ = '.';
+        *dst++ = '.';
+    }
+    *dst = 0;
+    return __wine_dbg_strdup( buffer );
+}
+
+static inline const char *wine_dbgstr_wn( const WCHAR *str, int n )
+{
+    static const char hex[16] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+    char buffer[300], *dst = buffer;
+
+    if (!str) return "(null)";
+    if (!((ULONG_PTR)str >> 16)) return wine_dbg_sprintf( "#%04x", LOWORD(str) );
+    if (IsBadStringPtrW( str, n )) return "(invalid)";
+    if (n == -1) for (n = 0; str[n]; n++) ;
+    *dst++ = 'L';
+    *dst++ = '"';
+    while (n-- > 0 && dst <= buffer + sizeof(buffer) - 10)
+    {
+        WCHAR c = *str++;
+        switch (c)
+        {
+        case '\n': *dst++ = '\\'; *dst++ = 'n'; break;
+        case '\r': *dst++ = '\\'; *dst++ = 'r'; break;
+        case '\t': *dst++ = '\\'; *dst++ = 't'; break;
+        case '"':  *dst++ = '\\'; *dst++ = '"'; break;
+        case '\\': *dst++ = '\\'; *dst++ = '\\'; break;
+        default:
+            if (c < ' ' || c >= 127)
+            {
+                *dst++ = '\\';
+                *dst++ = hex[(c >> 12) & 0x0f];
+                *dst++ = hex[(c >> 8) & 0x0f];
+                *dst++ = hex[(c >> 4) & 0x0f];
+                *dst++ = hex[c & 0x0f];
+            }
+            else *dst++ = (char)c;
+        }
+    }
+    *dst++ = '"';
+    if (n > 0)
+    {
+        *dst++ = '.';
+        *dst++ = '.';
+        *dst++ = '.';
+    }
+    *dst = 0;
+    return __wine_dbg_strdup( buffer );
+}
+
+static inline const char *wine_dbgstr_a( const char *s )
+{
+    return wine_dbgstr_an( s, -1 );
+}
+
+static inline const char *wine_dbgstr_w( const WCHAR *s )
+{
+    return wine_dbgstr_wn( s, -1 );
+}
+
+static inline const char *wine_dbgstr_guid( const GUID *id )
+{
+    if (!id) return "(null)";
+    if (!((ULONG_PTR)id >> 16)) return wine_dbg_sprintf( "<guid-0x%04hx>", (WORD)(ULONG_PTR)id );
+    return wine_dbg_sprintf( "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+                             id->Data1, id->Data2, id->Data3,
+                             id->Data4[0], id->Data4[1], id->Data4[2], id->Data4[3],
+                             id->Data4[4], id->Data4[5], id->Data4[6], id->Data4[7] );
+}
+
+static inline const char *wine_dbgstr_point( const POINT *pt )
+{
+    if (!pt) return "(null)";
+    return wine_dbg_sprintf( "(%d,%d)", pt->x, pt->y );
+}
+
+static inline const char *wine_dbgstr_rect( const RECT *rect )
+{
+    if (!rect) return "(null)";
+    return wine_dbg_sprintf( "(%d,%d)-(%d,%d)", rect->left, rect->top,
+                             rect->right, rect->bottom );
+}
+
+static inline const char *wine_dbgstr_longlong( ULONGLONG ll )
+{
+    if (sizeof(ll) > sizeof(unsigned long) && ll >> 32)
+        return wine_dbg_sprintf( "%lx%08lx", (unsigned long)(ll >> 32), (unsigned long)ll );
+    else return wine_dbg_sprintf( "%lx", (unsigned long)ll );
+}
+
+#if defined(__oaidl_h__) && defined(V_VT)
+
+static inline const char *wine_dbgstr_vt( VARTYPE vt )
+{
+    static const char *const variant_types[] =
+    {
+        "VT_EMPTY","VT_NULL","VT_I2","VT_I4","VT_R4","VT_R8","VT_CY","VT_DATE",
+        "VT_BSTR","VT_DISPATCH","VT_ERROR","VT_BOOL","VT_VARIANT","VT_UNKNOWN",
+        "VT_DECIMAL","15","VT_I1","VT_UI1","VT_UI2","VT_UI4","VT_I8","VT_UI8",
+        "VT_INT","VT_UINT","VT_VOID","VT_HRESULT","VT_PTR","VT_SAFEARRAY",
+        "VT_CARRAY","VT_USERDEFINED","VT_LPSTR","VT_LPWSTR","32","33","34","35",
+        "VT_RECORD","VT_INT_PTR","VT_UINT_PTR","39","40","41","42","43","44","45",
+        "46","47","48","49","50","51","52","53","54","55","56","57","58","59","60",
+        "61","62","63","VT_FILETIME","VT_BLOB","VT_STREAM","VT_STORAGE",
+        "VT_STREAMED_OBJECT","VT_STORED_OBJECT","VT_BLOB_OBJECT","VT_CF","VT_CLSID",
+        "VT_VERSIONED_STREAM"
+    };
+
+    static const char *const variant_flags[16] =
+    {
+        "",
+        "|VT_VECTOR",
+        "|VT_ARRAY",
+        "|VT_VECTOR|VT_ARRAY",
+        "|VT_BYREF",
+        "|VT_VECTOR|VT_BYREF",
+        "|VT_ARRAY|VT_BYREF",
+        "|VT_VECTOR|VT_ARRAY|VT_BYREF",
+        "|VT_RESERVED",
+        "|VT_VECTOR|VT_RESERVED",
+        "|VT_ARRAY|VT_RESERVED",
+        "|VT_VECTOR|VT_ARRAY|VT_RESERVED",
+        "|VT_BYREF|VT_RESERVED",
+        "|VT_VECTOR|VT_BYREF|VT_RESERVED",
+        "|VT_ARRAY|VT_BYREF|VT_RESERVED",
+        "|VT_VECTOR|VT_ARRAY|VT_BYREF|VT_RESERVED",
+    };
+
+    if (vt & ~VT_TYPEMASK)
+        return wine_dbg_sprintf( "%s%s", wine_dbgstr_vt(vt&VT_TYPEMASK), variant_flags[vt>>12] );
+
+    if (vt < sizeof(variant_types)/sizeof(*variant_types))
+        return variant_types[vt];
+
+    if (vt == VT_BSTR_BLOB)
+        return "VT_BSTR_BLOB";
+
+    return wine_dbg_sprintf( "vt(invalid %x)", vt );
+}
+
+static inline const char *wine_dbgstr_variant( const VARIANT *v )
+{
+    if (!v)
+        return "(null)";
+
+    if (V_VT(v) & VT_BYREF) {
+        if (V_VT(v) == (VT_VARIANT|VT_BYREF))
+            return wine_dbg_sprintf( "%p {VT_VARIANT|VT_BYREF: %s}", v, wine_dbgstr_variant(V_VARIANTREF(v)) );
+        if (V_VT(v) == (VT_BSTR|VT_BYREF))
+            return wine_dbg_sprintf( "%p {VT_BSTR|VT_BYREF: %s}", v, V_BSTRREF(v) ? wine_dbgstr_w(*V_BSTRREF(v)) : "(none)" );
+        return wine_dbg_sprintf( "%p {%s %p}", v, wine_dbgstr_vt(V_VT(v)), V_BYREF(v) );
+    }
+
+    if (V_ISARRAY(v) || V_ISVECTOR(v))
+        return wine_dbg_sprintf( "%p {%s %p}", v, wine_dbgstr_vt(V_VT(v)), V_ARRAY(v) );
+
+    switch(V_VT(v)) {
+    case VT_EMPTY:
+        return wine_dbg_sprintf( "%p {VT_EMPTY}", v );
+    case VT_NULL:
+        return wine_dbg_sprintf( "%p {VT_NULL}", v );
+    case VT_I2:
+        return wine_dbg_sprintf( "%p {VT_I2: %d}", v, V_I2(v) );
+    case VT_I4:
+        return wine_dbg_sprintf( "%p {VT_I4: %d}", v, V_I4(v) );
+    case VT_R4:
+        return wine_dbg_sprintf( "%p {VT_R4: %f}", v, V_R4(v) );
+    case VT_R8:
+        return wine_dbg_sprintf( "%p {VT_R8: %lf}", v, V_R8(v) );
+    case VT_CY:
+        return wine_dbg_sprintf( "%p {VT_CY: %s}", v, wine_dbgstr_longlong(V_CY(v).int64) );
+    case VT_DATE:
+        return wine_dbg_sprintf( "%p {VT_DATE: %lf}", v, V_DATE(v) );
+    case VT_LPSTR:
+        return wine_dbg_sprintf( "%p {VT_LPSTR: %s}", v, wine_dbgstr_a((const char *)V_BSTR(v)) );
+    case VT_LPWSTR:
+        return wine_dbg_sprintf( "%p {VT_LPWSTR: %s}", v, wine_dbgstr_w(V_BSTR(v)) );
+    case VT_BSTR:
+        return wine_dbg_sprintf( "%p {VT_BSTR: %s}", v, wine_dbgstr_w(V_BSTR(v)) );
+    case VT_DISPATCH:
+        return wine_dbg_sprintf( "%p {VT_DISPATCH: %p}", v, V_DISPATCH(v) );
+    case VT_ERROR:
+        return wine_dbg_sprintf( "%p {VT_ERROR: %08x}", v, V_ERROR(v) );
+    case VT_BOOL:
+        return wine_dbg_sprintf( "%p {VT_BOOL: %x}", v, V_BOOL(v) );
+    case VT_UNKNOWN:
+        return wine_dbg_sprintf( "%p {VT_UNKNOWN: %p}", v, V_UNKNOWN(v) );
+    case VT_I1:
+        return wine_dbg_sprintf( "%p {VT_I1: %d}", v, V_I1(v) );
+    case VT_UI1:
+        return wine_dbg_sprintf( "%p {VT_UI1: %u}", v, V_UI1(v) );
+    case VT_UI2:
+        return wine_dbg_sprintf( "%p {VT_UI2: %d}", v, V_UI2(v) );
+    case VT_UI4:
+        return wine_dbg_sprintf( "%p {VT_UI4: %d}", v, V_UI4(v) );
+    case VT_I8:
+        return wine_dbg_sprintf( "%p {VT_I8: %s}", v, wine_dbgstr_longlong(V_I8(v)) );
+    case VT_UI8:
+        return wine_dbg_sprintf( "%p {VT_UI8: %s}", v, wine_dbgstr_longlong(V_UI8(v)) );
+    case VT_INT:
+        return wine_dbg_sprintf( "%p {VT_INT: %d}", v, V_INT(v) );
+    case VT_UINT:
+        return wine_dbg_sprintf( "%p {VT_UINT: %u}", v, V_UINT(v) );
+    case VT_VOID:
+        return wine_dbg_sprintf( "%p {VT_VOID}", v );
+    case VT_RECORD:
+        return wine_dbg_sprintf( "%p {VT_RECORD: %p %p}", v, V_RECORD(v), V_RECORDINFO(v) );
+    default:
+        return wine_dbg_sprintf( "%p {vt %s}", v, wine_dbgstr_vt(V_VT(v)) );
+    }
+}
+
+#endif /* defined(__oaidl_h__) && defined(V_VT) */
+
+#ifndef WINE_TRACE
+#define WINE_TRACE                 __WINE_DPRINTF(_TRACE,__wine_dbch___default)
+#define WINE_TRACE_(ch)            __WINE_DPRINTF(_TRACE,&__wine_dbch_##ch)
+#endif
+#define WINE_TRACE_ON(ch)          __WINE_IS_DEBUG_ON(_TRACE,&__wine_dbch_##ch)
+
+#ifndef WINE_WARN
+#define WINE_WARN                  __WINE_DPRINTF(_WARN,__wine_dbch___default)
+#define WINE_WARN_(ch)             __WINE_DPRINTF(_WARN,&__wine_dbch_##ch)
+#endif
+#define WINE_WARN_ON(ch)           __WINE_IS_DEBUG_ON(_WARN,&__wine_dbch_##ch)
+
+#ifndef WINE_FIXME
+#define WINE_FIXME                 __WINE_DPRINTF(_FIXME,__wine_dbch___default)
+#define WINE_FIXME_(ch)            __WINE_DPRINTF(_FIXME,&__wine_dbch_##ch)
+#endif
+#define WINE_FIXME_ON(ch)          __WINE_IS_DEBUG_ON(_FIXME,&__wine_dbch_##ch)
+
+#define WINE_ERR                   __WINE_DPRINTF(_ERR,__wine_dbch___default)
+#define WINE_ERR_(ch)              __WINE_DPRINTF(_ERR,&__wine_dbch_##ch)
+#define WINE_ERR_ON(ch)            __WINE_IS_DEBUG_ON(_ERR,&__wine_dbch_##ch)
+
+#define WINE_DECLARE_DEBUG_CHANNEL(ch) \
+    static struct __wine_debug_channel __wine_dbch_##ch = { 0xff, #ch }
+#define WINE_DEFAULT_DEBUG_CHANNEL(ch) \
+    static struct __wine_debug_channel __wine_dbch_##ch = { 0xff, #ch }; \
+    static struct __wine_debug_channel * const __wine_dbch___default = &__wine_dbch_##ch
+
+#define WINE_MESSAGE               wine_dbg_printf
+
+#ifdef __WINESRC__
+/* Wine uses shorter names that are very likely to conflict with other software */
+
+static inline const char *debugstr_an( const char * s, int n ) { return wine_dbgstr_an( s, n ); }
+static inline const char *debugstr_wn( const WCHAR *s, int n ) { return wine_dbgstr_wn( s, n ); }
+static inline const char *debugstr_guid( const struct _GUID *id ) { return wine_dbgstr_guid(id); }
+static inline const char *debugstr_a( const char *s )  { return wine_dbgstr_an( s, -1 ); }
+static inline const char *debugstr_w( const WCHAR *s ) { return wine_dbgstr_wn( s, -1 ); }
+
+#if defined(__oaidl_h__) && defined(V_VT)
+static inline const char *debugstr_vt( VARTYPE vt ) { return wine_dbgstr_vt( vt ); }
+static inline const char *debugstr_variant( const VARIANT *v ) { return wine_dbgstr_variant( v ); }
+#endif
+
+#define TRACE                      WINE_TRACE
+#define TRACE_(ch)                 WINE_TRACE_(ch)
+#define TRACE_ON(ch)               WINE_TRACE_ON(ch)
+
+#define WARN                       WINE_WARN
+#define WARN_(ch)                  WINE_WARN_(ch)
+#define WARN_ON(ch)                WINE_WARN_ON(ch)
+
+#define FIXME                      WINE_FIXME
+#define FIXME_(ch)                 WINE_FIXME_(ch)
+#define FIXME_ON(ch)               WINE_FIXME_ON(ch)
+
+#undef ERR  /* Solaris got an 'ERR' define in <sys/reg.h> */
+#define ERR                        WINE_ERR
+#define ERR_(ch)                   WINE_ERR_(ch)
+#define ERR_ON(ch)                 WINE_ERR_ON(ch)
+
+#define MESSAGE                    WINE_MESSAGE
+
+#endif /* __WINESRC__ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __WINE_WINE_DEBUG_H */

--- a/wine/heap.h
+++ b/wine/heap.h
@@ -1,0 +1,58 @@
+/*
+ * Wine heap memory allocation wrappers
+ *
+ * Copyright 2006 Jacek Caban for CodeWeavers
+ * Copyright 2013, 2018 Michael Stefaniuc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __WINE_WINE_HEAP_H
+#define __WINE_WINE_HEAP_H
+
+#include <winbase.h>
+
+static inline void * heap_alloc(SIZE_T len)
+{
+    return HeapAlloc(GetProcessHeap(), 0, len);
+}
+
+static inline void * heap_alloc_zero(SIZE_T len)
+{
+    return HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, len);
+}
+
+static inline void * heap_realloc(void *mem, SIZE_T len)
+{
+    if (!mem)
+        return HeapAlloc(GetProcessHeap(), 0, len);
+    return HeapReAlloc(GetProcessHeap(), 0, mem, len);
+}
+
+static inline void heap_free(void *mem)
+{
+    HeapFree(GetProcessHeap(), 0, mem);
+}
+
+static inline void *heap_calloc(SIZE_T count, SIZE_T size)
+{
+    SIZE_T len = count * size;
+
+    if (size && len / size != count)
+        return NULL;
+    return HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, len);
+}
+
+#endif  /* __WINE_WINE_HEAP_H */


### PR DESCRIPTION
This will make it possible to run native XNA games which are still using WMV/WMA assets in Wine.

It requires FAudio changes for XNA Song WMA support, tracked in https://github.com/FNA-XNA/FAudio/pull/253 as well as some Wine Mono build changes to build and install the new FNAMF native wrapper.

I'm not sure if it would be interesting to submit upstream, at least probably they won't be interested in this form as it's not configurable.