### PR TITLE
Don't throw exception for missing Video until its played

### DIFF
--- a/src/Content/ContentReaders/VideoReader.cs
+++ b/src/Content/ContentReaders/VideoReader.cs
@@ -41,10 +41,11 @@ namespace Microsoft.Xna.Framework.Content
 			/* The path string includes the ".wmv" extension. Let's see if this
 			 * file exists in a format we actually support...
 			 */
+			string origpath = path;
 			path = Normalize(path.Substring(0, path.Length - 4));
 			if (String.IsNullOrEmpty(path))
 			{
-				throw new ContentLoadException();
+				path = origpath;
 			}
 
 			int durationMS = input.ReadObject<int>();

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -89,38 +89,41 @@ namespace Microsoft.Xna.Framework.Media
 
 			Theorafile.th_pixel_fmt fmt;
 			Theorafile.tf_fopen(fileName, out theora);
-			Theorafile.tf_videoinfo(
-				theora,
-				out yWidth,
-				out yHeight,
-				out fps,
-				out fmt
-			);
-			if (fmt == Theorafile.th_pixel_fmt.TH_PF_420)
+			if (theora != IntPtr.Zero)
 			{
-				uvWidth = yWidth / 2;
-				uvHeight = yHeight / 2;
-			}
-			else if (fmt == Theorafile.th_pixel_fmt.TH_PF_422)
-			{
-				uvWidth = yWidth / 2;
-				uvHeight = yHeight;
-			}
-			else if (fmt == Theorafile.th_pixel_fmt.TH_PF_444)
-			{
-				uvWidth = yWidth;
-				uvHeight = yHeight;
-			}
-			else
-			{
-				throw new NotSupportedException(
-					"Unrecognized YUV format!"
+				Theorafile.tf_videoinfo(
+					theora,
+					out yWidth,
+					out yHeight,
+					out fps,
+					out fmt
 				);
-			}
+				if (fmt == Theorafile.th_pixel_fmt.TH_PF_420)
+				{
+					uvWidth = yWidth / 2;
+					uvHeight = yHeight / 2;
+				}
+				else if (fmt == Theorafile.th_pixel_fmt.TH_PF_422)
+				{
+					uvWidth = yWidth / 2;
+					uvHeight = yHeight;
+				}
+				else if (fmt == Theorafile.th_pixel_fmt.TH_PF_444)
+				{
+					uvWidth = yWidth;
+					uvHeight = yHeight;
+				}
+				else
+				{
+					throw new NotSupportedException(
+						"Unrecognized YUV format!"
+					);
+				}
 
-			// FIXME: This is a part of the Duration hack!
-			Duration = TimeSpan.MaxValue;
-			needsDurationHack = true;
+				// FIXME: This is a part of the Duration hack!
+				Duration = TimeSpan.MaxValue;
+				needsDurationHack = true;
+			}
 		}
 
 		internal Video(
@@ -135,6 +138,13 @@ namespace Microsoft.Xna.Framework.Media
 			// FIXME: Oh, hey! I wish we had this info in Theora!
 			Duration = TimeSpan.FromMilliseconds(durationMS);
 			needsDurationHack = false;
+
+			if (theora == IntPtr.Zero)
+			{
+				yWidth = width;
+				yHeight = height;
+				fps = framesPerSecond;
+			}
 
 			VideoSoundtrackType = soundtrackType;
 		}

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -594,6 +594,15 @@ namespace Microsoft.Xna.Framework.Media
 
 		public void Play(Video video)
 		{
+			if (video == null)
+			{
+				throw new System.ArgumentNullException();
+			}
+			if (video.theora == IntPtr.Zero)
+			{
+				throw new System.ArgumentException();
+			}
+
 			checkDisposed();
 
 			// We need to assign this regardless of what happens next.


### PR DESCRIPTION
Windows doesn't throw an exception if a Video file is missing until you try to play it.

This PR looks to modify FNA to behave the same way as Windows.

This fixes a crash in Hell Yeah! Wrath of the Dead Rabbit (205230) when loading into the First Boss Door.